### PR TITLE
evolinc-i deletes fastq.gz files in directory where it is run - issue fixed!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
-FROM ubuntu:14.04.3
-MAINTAINER Upendra Devisetty
+FROM ubuntu:18.04
+LABEL Chosen Obih
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y g++ \
 		make \
 		git \
 		zlib1g-dev \
+		openssl \
+		lbzip2 \
+		bzip2 \
 		python \
+		python2.7-dev \
 		perl \
 		wget \
 		curl \
@@ -44,13 +49,14 @@ RUN curl -L http://cpanmin.us | perl - App::cpanminus
 RUN cpanm URI/Escape.pm
 
 # R libraries
-RUN echo "deb http://cran.cnr.berkeley.edu/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 51716619E084DAB9
-RUN apt-get update
-RUN apt-get install -y r-base r-base-dev
+RUN apt-get -y install ca-certificates software-properties-common gnupg2 gnupg1 gnupg
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
+RUN add-apt-repository "deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran35/"
+RUN apt-get install -y r-base
 RUN Rscript -e 'install.packages("splitstackshape", dependencies = TRUE, repos="http://cran.rstudio.com/");'
 RUN Rscript -e 'install.packages("dplyr", dependencies = TRUE, repos="http://cran.rstudio.com/");'
-RUN Rscript -e 'source("https://bioconductor.org/biocLite.R"); biocLite("Biostrings");'
+RUN Rscript -e 'if (!requireNamespace("BiocManager", quietly = TRUE)){install.packages("BiocManager")};'
+RUN Rscript -e 'BiocManager::install(c("Biostrings"));'
 RUN Rscript -e 'install.packages("getopt", dependencies = TRUE, repos="http://cran.rstudio.com/");'
 
 # Uniprot database
@@ -61,11 +67,17 @@ RUN gzip -d /evolinc_docker/uniprot_sprot.dmnd.gz
 ADD https://de.cyverse.org/dl/d/12EF1A2F-B9FC-456D-8CD9-9F87197CACF2/rFAM_sequences.fasta /evolinc_docker/
 
 # Biopython
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
-RUN python get-pip.py
-RUN pip install biopython
+RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
+RUN curl "https://files.pythonhosted.org/packages/27/79/8a850fe3496446ff0d584327ae44e7500daf6764ca1a382d2d02789accf7/pip-20.3.4-py2.py3-none-any.whl" -o "pip-20.3.4-py2.py3-none-any.whl"
+RUN curl "https://files.pythonhosted.org/packages/e1/b7/182161210a13158cd3ccc41ee19aadef54496b74f2817cc147006ec932b4/setuptools-44.1.1-py2.py3-none-any.whl" -o "setuptools-44.1.1-py2.py3-none-any.whl"
+RUN curl "https://files.pythonhosted.org/packages/27/d6/003e593296a85fd6ed616ed962795b2f87709c3eee2bca4f6d0fe55c6d00/wheel-0.37.1-py2.py3-none-any.whl" -o "wheel-0.37.1-py2.py3-none-any.whl"
+RUN python get-pip.py "pip-20.3.4-py2.py3-none-any.whl" "setuptools-44.1.1-py2.py3-none-any.whl" "wheel-0.37.1-py2.py3-none-any.whl"
+RUN curl "https://files.pythonhosted.org/packages/ff/f4/0ce39bebcbb0ff619426f2bbe86e60bc549ace318c5a9113ae480ab2adc7/biopython-1.76.tar.gz" -o "biopython-1.76.tar.gz"
+RUN tar xvf biopython-1.76.tar.gz
+RUN cd biopython-1.76 && python setup.py build && python setup.py install
+RUN cd ..
 
-# CPC2 (modified)
+# CPC2
 ADD CPC2-beta /evolinc_docker/CPC2-beta
 WORKDIR /evolinc_docker/CPC2-beta/libs/libsvm/
 RUN tar xvf libsvm-3.22.tar.gz
@@ -74,10 +86,10 @@ RUN make clean && make
 WORKDIR /
 
 #LAST
-RUN wget http://last.cbrc.jp/last-926.zip
+RUN wget https://gitlab.com/mcfrith/last/-/archive/main/last-main.zip
 RUN apt-get install -y unzip
-RUN unzip last-926.zip
-WORKDIR last-926
+RUN unzip last-main.zip
+WORKDIR last-main
 RUN make
 RUN make install prefix=~
 
@@ -94,7 +106,7 @@ ENV PATH /evolinc_docker/bedtools2-2.25.0/bin/:$PATH
 ENV PATH /evolinc_docker/samtools-bcftools-htslib-1.0_x64-linux/bin/:$PATH
 ENV PATH /evolinc_docker/bin/:$PATH
 ENV PATH /evolinc_docker/CPC2-beta/bin/:$PATH
-ENV PATH /last-926/src/:$PATH
+ENV PATH /last-main/src/:$PATH
 ENV PATH /evolinc_docker/:$PATH
 
 # Entrypoint

--- a/evolinc-part-I.sh
+++ b/evolinc-part-I.sh
@@ -625,7 +625,8 @@ echo "Elapsed time for Optional Step(s) is" $ELAPSED_TIME_O1 "seconds" >> ../$ou
 
 # # remove all the other files
 rm -r ../transcripts_u_filter.fa.transdecoder_dir
-rm ../*.fa*.*
+#rm ../*.fa*.*
+rm ../referencegenome.fa.fai
 
 ### Clean up fasta headers
 cd ../$output


### PR DESCRIPTION
Hi evolinc team,

I am using evolinc-i in a new workflow that I am developing. During a test run, I noticed that the evolinc-i program deletes any fastq.gz file contained in the directory where it is run. I took a look at the evolinc-part-I.sh script and I noticed that the problem was caused by the code in line #628 <rm ../*.fa*.*>. I fixed this issue and also updated the Dockerfile. 